### PR TITLE
Fix boot.sh to keep /tmp

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -95,7 +95,7 @@ chmod -R 775 /opt/openhab
 
 ######################
 # Decide how to launch
-rm -rf /tmp/
+rm -rf /tmp/*
 ETH0_FOUND=`grep "eth0" /proc/net/dev`
 
 if [ -n "$ETH0_FOUND" ] ;


### PR DESCRIPTION
/tmp folder is needed for Webinterface (/static,/images,/habmin) to start up correctly
